### PR TITLE
Fix main page styles

### DIFF
--- a/src/components/Editors/Editors.module.scss
+++ b/src/components/Editors/Editors.module.scss
@@ -4,7 +4,7 @@
 
 .container {
   width: 100%;
-  min-height: 100vh;
+  min-height: max(500px, 100vh - 56px);
   display: flex;
   justify-content: space-between;
 }

--- a/src/components/Editors/editors/HeadersEditor/HeadersEditor.module.scss
+++ b/src/components/Editors/editors/HeadersEditor/HeadersEditor.module.scss
@@ -1,7 +1,8 @@
 .headersEditor {
   height: 30vh;
   font-size: 16px;
-  background-color: #f5f5f5;
+  border: 1px solid;
+  background-color: #ffffff;
   font-family: 'Fira Code', monospace;
   border-radius: 10px;
   padding: 15px;

--- a/src/components/Editors/editors/OperationEditor/OperationEditor.module.scss
+++ b/src/components/Editors/editors/OperationEditor/OperationEditor.module.scss
@@ -8,7 +8,8 @@
 .operationCode {
   height: 100%;
   font-size: 16px;
-  background-color: #f5f5f5;
+  border: 1px solid;
+  background-color: #ffffff;
   font-family: 'Fira Code', monospace;
   border-radius: 10px;
   padding: 15px;

--- a/src/components/Editors/editors/Response/Response.module.scss
+++ b/src/components/Editors/editors/Response/Response.module.scss
@@ -20,7 +20,7 @@
   }
 }
 .responseCode {
-  height: 100vh;
+  height: 100%;
   font-size: 16px;
   background-color: #f5f5f5;
   font-family: 'Fira Code', monospace;

--- a/src/components/Editors/editors/Response/Response.module.scss
+++ b/src/components/Editors/editors/Response/Response.module.scss
@@ -10,13 +10,14 @@
 .loaderWrapper {
   position: absolute;
   display: block;
-  width: 100%;
-  height: 100%;
-  background-color: white;
+  width: calc(100% - 32px);
+  height: calc(100% - 32px);
   z-index: 3;
+  background-color: #f5f5f5;
+  border-radius: 10px;
   .loader {
     margin: auto;
-    top: calc(50% - 60px);
+    top: calc(50% - 60px / 2);
   }
 }
 .responseCode {

--- a/src/components/Editors/editors/VariablesEditor/VariablesEditor.module.scss
+++ b/src/components/Editors/editors/VariablesEditor/VariablesEditor.module.scss
@@ -1,7 +1,8 @@
 .variablesCode {
   height: 30vh;
   font-size: 16px;
-  background-color: #f5f5f5;
+  border: 1px solid;
+  background-color: #ffffff;
   font-family: 'Fira Code', monospace;
   border-radius: 10px;
   padding: 15px;

--- a/src/components/Editors/index.tsx
+++ b/src/components/Editors/index.tsx
@@ -14,7 +14,7 @@ export const Editors = () => {
   const [variables, setVariables] = useState('');
   const [headers, setHeaders] = useState('');
   const [parseError, setParseError] = useState('');
-  const [tab, setTab] = useState<string | null>('variables');
+  const [tab, setTab] = useState<string | null>(null);
 
   const { t } = useTranslation();
 

--- a/src/scss/components/_docs.scss
+++ b/src/scss/components/_docs.scss
@@ -4,10 +4,12 @@
 }
 
 .documentation {
+  flex-direction: row-reverse;
   .docs {
     width: 290px;
     padding: 16px;
-    min-height: 100%;
+    height: max(500px, 100vh - 56px);
+    overflow: auto;
   }
 
   .btn {
@@ -20,6 +22,7 @@
     }
   }
   @include media-breakpoint-down(lg) {
+    flex-direction: row;
     .docs {
       width: 100%;
       height: 50vh;


### PR DESCRIPTION
The following problems have been addressed:

1. Text was not clearly visible on the editor background due to low contrast. The fix increases the contrast to make the text legible.
2. The documentation did not adjust to the size of the editor fields on desktop resolutions, causing the page to jerk. The fix adds minimum and maximum widths for the editors and documentation, ensuring that the variables/headers tabs are visible on the screen when the page loads, allowing users to easily find them.
3. The response loader overflowed its container and did not fit properly on the page.

![image](https://github.com/iscoulfi/graphiql-app/assets/90222151/19ee56f9-6960-4142-bdf1-b62b5d425d9e)
