### PR TITLE
Fix classnames

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@reduxjs/toolkit": "^1.9.5",
         "@uiw/react-textarea-code-editor": "^2.1.1",
         "bootstrap": "^5.2.3",
+        "classnames": "^2.3.2",
         "firebase": "^9.21.0",
         "graphql": "^16.6.0",
         "i18next": "^22.4.15",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@reduxjs/toolkit": "^1.9.5",
     "@uiw/react-textarea-code-editor": "^2.1.1",
     "bootstrap": "^5.2.3",
+    "classnames": "^2.3.2",
     "firebase": "^9.21.0",
     "graphql": "^16.6.0",
     "i18next": "^22.4.15",

--- a/src/components/Header/components/HeaderAuthentication/index.tsx
+++ b/src/components/Header/components/HeaderAuthentication/index.tsx
@@ -7,7 +7,7 @@ import { Button } from 'react-bootstrap';
 import styles from './HeaderAuthentication.module.scss';
 import classNames from 'classnames';
 
-export const HeaderAuthentication = ({ className }: { className: string }) => {
+export const HeaderAuthentication = ({ isSticky }: { isSticky: boolean }) => {
   const [user, loading] = useAuthState(auth);
 
   const navigate = useNavigate();
@@ -23,14 +23,18 @@ export const HeaderAuthentication = ({ className }: { className: string }) => {
     return (
       <div>
         <Button
-          className={classNames('border-0', className)}
+          className={classNames('border-0', { 'text-white': isSticky })}
           size="sm"
           variant=""
           onClick={() => navigate('/auth')}
         >
           {t('Header sign in')}
         </Button>
-        <Button size="sm" className={className} onClick={() => navigate('/auth?signup=true')}>
+        <Button
+          size="sm"
+          className={classNames({ 'text-white': isSticky })}
+          onClick={() => navigate('/auth?signup=true')}
+        >
           {t('Header sign up')}
         </Button>
       </div>

--- a/src/components/Header/components/HeaderAuthentication/index.tsx
+++ b/src/components/Header/components/HeaderAuthentication/index.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from 'react-i18next';
 import { TbLogout } from 'react-icons/tb';
 import { Button } from 'react-bootstrap';
 import styles from './HeaderAuthentication.module.scss';
+import classNames from 'classnames';
 
 export const HeaderAuthentication = ({ className }: { className: string }) => {
   const [user, loading] = useAuthState(auth);
@@ -22,7 +23,7 @@ export const HeaderAuthentication = ({ className }: { className: string }) => {
     return (
       <div>
         <Button
-          className={`border-0 ${className}`}
+          className={classNames('border-0', className)}
           size="sm"
           variant=""
           onClick={() => navigate('/auth')}

--- a/src/components/Header/components/LanguageSelector/index.tsx
+++ b/src/components/Header/components/LanguageSelector/index.tsx
@@ -1,9 +1,10 @@
 import { useTranslation } from 'react-i18next';
 import { ButtonGroup, Button } from 'react-bootstrap';
+import classNames from 'classnames';
 
 type Language = 'en' | 'ru';
 
-export const LanguageSelector = ({ className }: { className: string }) => {
+export const LanguageSelector = ({ isSticky }: { isSticky: boolean }) => {
   const { i18n } = useTranslation();
 
   const changeLanguage = (language: Language) => {
@@ -18,7 +19,7 @@ export const LanguageSelector = ({ className }: { className: string }) => {
         active={isActive('en')}
         variant="outline-secondary"
         onClick={() => changeLanguage('en')}
-        className={className}
+        className={classNames({ 'text-white': isSticky })}
       >
         EN
       </Button>
@@ -26,7 +27,7 @@ export const LanguageSelector = ({ className }: { className: string }) => {
         active={isActive('ru')}
         variant="outline-secondary"
         onClick={() => changeLanguage('ru')}
-        className={className}
+        className={classNames({ 'text-white': isSticky })}
       >
         RU
       </Button>

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Container, Navbar } from 'react-bootstrap';
 import { HeaderAuthentication, LanguageSelector } from './components';
+import classNames from 'classnames';
 
 export const Header = () => {
   const [isSticky, setIsSticky] = useState(false);
@@ -22,7 +23,10 @@ export const Header = () => {
   const navigate = useNavigate();
 
   return (
-    <Navbar className={`border-bottom header ${isSticky ? 'bg-dark text-white' : ''}`} sticky="top">
+    <Navbar
+      className={classNames('border-bottom header', { 'bg-dark text-white': isSticky })}
+      sticky="top"
+    >
       <Container>
         <Navbar.Brand className="link" onClick={() => navigate('/')}>
           <img
@@ -34,8 +38,8 @@ export const Header = () => {
           />
         </Navbar.Brand>
         <Container className="d-flex justify-content-end p-0">
-          <HeaderAuthentication className={isSticky ? 'text-white' : ''} />
-          <LanguageSelector className={isSticky ? 'text-white' : ''} />
+          <HeaderAuthentication className={classNames({ 'text-white': isSticky })} />
+          <LanguageSelector className={classNames({ 'text-white': isSticky })} />
         </Container>
       </Container>
     </Navbar>

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -38,8 +38,8 @@ export const Header = () => {
           />
         </Navbar.Brand>
         <Container className="d-flex justify-content-end p-0">
-          <HeaderAuthentication className={classNames({ 'text-white': isSticky })} />
-          <LanguageSelector className={classNames({ 'text-white': isSticky })} />
+          <HeaderAuthentication isSticky={isSticky} />
+          <LanguageSelector isSticky={isSticky} />
         </Container>
       </Container>
     </Navbar>


### PR DESCRIPTION
1. The `classnames` package has been installed
2. Manual concatenation of class names has been replaced with the `classnames` library, resulting in cleaner code
3. Replaced `className` prop with `isSticky` in  HeaderAuthentication and LanguageSelector